### PR TITLE
feat: 민감정보 저장 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Secrets ###
+src/main/resources/secrets.conf

--- a/src/main/kotlin/Application.kt
+++ b/src/main/kotlin/Application.kt
@@ -6,6 +6,7 @@ import com.example.module.configureRouting
 import com.example.module.configureSecurity
 import com.example.module.configureSerialization
 import io.ktor.server.application.Application
+import io.ktor.server.config.ApplicationConfig
 
 fun main(args: Array<String>) {
     io.ktor.server.netty.EngineMain.main(args)
@@ -18,3 +19,6 @@ fun Application.module() {
     configureDatabases()
     configureRouting()
 }
+
+internal val config = ApplicationConfig("application.conf")
+internal val secretConfig = ApplicationConfig("secrets.conf")

--- a/src/main/kotlin/module/Security.kt
+++ b/src/main/kotlin/module/Security.kt
@@ -2,6 +2,8 @@ package com.example.module
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
+import com.example.config
+import com.example.secretConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.apache.Apache
 import io.ktor.http.HttpMethod
@@ -13,6 +15,7 @@ import io.ktor.server.auth.authentication
 import io.ktor.server.auth.jwt.JWTPrincipal
 import io.ktor.server.auth.jwt.jwt
 import io.ktor.server.auth.oauth
+import io.ktor.server.config.tryGetString
 import io.ktor.server.response.respondRedirect
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
@@ -20,11 +23,10 @@ import io.ktor.server.sessions.sessions
 import io.ktor.server.sessions.set
 
 fun Application.configureSecurity() {
-    // Please read the jwt property from the config file if you are using EngineMain
-    val jwtAudience = "jwt-audience"
-    val jwtDomain = "https://jwt-provider-domain/"
-    val jwtRealm = "ktor sample app"
-    val jwtSecret = "secret"
+    val jwtAudience = config.tryGetString("jwt.audience")!!
+    val jwtDomain = config.tryGetString("jwt.domain")!!
+    val jwtRealm = config.tryGetString("jwt.realm")!!
+    val jwtSecret = secretConfig.tryGetString("jwt.secret")!!
     authentication {
         jwt {
             realm = jwtRealm
@@ -49,8 +51,8 @@ fun Application.configureSecurity() {
                     authorizeUrl = "https://accounts.google.com/o/oauth2/auth",
                     accessTokenUrl = "https://accounts.google.com/o/oauth2/token",
                     requestMethod = HttpMethod.Post,
-                    clientId = System.getenv("GOOGLE_CLIENT_ID"),
-                    clientSecret = System.getenv("GOOGLE_CLIENT_SECRET"),
+                    clientId = secretConfig.tryGetString("oauth-google.client-id")!!,
+                    clientSecret = secretConfig.tryGetString("oauth-google.client-secret")!!,
                     defaultScopes = listOf("https://www.googleapis.com/auth/userinfo.profile")
                 )
             }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -7,6 +7,7 @@ ktor {
         modules = [ com.example.ApplicationKt.module ]
     }
 }
+
 jwt {
     domain = "https://jwt-provider-domain/"
     audience = "jwt-audience"

--- a/src/main/resources/secrets.conf
+++ b/src/main/resources/secrets.conf
@@ -1,8 +1,0 @@
-jwt {
-    secret: ""
-}
-
-oauth-google {
-    client-id: ""
-    client-secret: ""
-}

--- a/src/main/resources/secrets.conf
+++ b/src/main/resources/secrets.conf
@@ -1,0 +1,8 @@
+jwt {
+    secret: ""
+}
+
+oauth-google {
+    client-id: ""
+    client-secret: ""
+}


### PR DESCRIPTION
## 🔥 AS-IS

- 

## 🚀 TO-BE

- 민감정보를 저장하는 별도 `secrets.conf` 추가
- jwt 시크릿과 google oauth 시크릿을 `secrets.conf`에 저장한다.
- 추후 환경변수로 관리할 수 있도록 한다.

## 📝 리뷰시 중점 사항

- 

## ✅ 체크 리스트 

- [x] 코드가 의도한 대로 동작하는가?

## 🔗 관련 이슈
#### (이슈 넘버가 있다면 적어주세요.)

-  
