### PR TITLE
feat: 이미 발급 요청한 리프레시 토큰이 재사용될 수 없게 한다.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:$logback_version")
 
     implementation("io.arrow-kt:arrow-core:2.0.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
 
     testImplementation("io.ktor:ktor-server-test-host")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,6 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:$logback_version")
 
     implementation("io.arrow-kt:arrow-core:2.0.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
 
     testImplementation("io.ktor:ktor-server-test-host")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")

--- a/src/main/kotlin/Application.kt
+++ b/src/main/kotlin/Application.kt
@@ -24,8 +24,7 @@ import io.ktor.server.netty.EngineMain
 import java.time.Clock
 
 fun main(args: Array<String>) {
-    EngineMain
-        .main(args)
+    EngineMain.main(args)
 }
 
 internal fun Application.module() {
@@ -70,7 +69,7 @@ internal fun Application.module() {
 
     val tokenProvider = TokenProvider(appConfig.jwt, clock)
     val tokenValidator = TokenValidator(appConfig.jwt)
-    val refreshTokenRepository = MongoRefreshTokenRepository(refreshTokenDao(appConfig.mongoRefreshToken), clock)
+    val refreshTokenRepository = MongoRefreshTokenRepository(refreshTokenDao(appConfig.mongoRefreshToken))
 
     // configure
     configureSecurity(

--- a/src/main/kotlin/Application.kt
+++ b/src/main/kotlin/Application.kt
@@ -68,7 +68,7 @@ internal fun Application.module() {
     val userAuthorizationService = UserAuthorizationService(userEmailRepository, userRepository, clock)
 
     val tokenProvider = TokenProvider(appConfig.jwt, clock)
-    val tokenValidator = TokenValidator(appConfig.jwt)
+    val tokenValidator = TokenValidator(appConfig.jwt, clock)
     val refreshTokenRepository = MongoRefreshTokenRepository(refreshTokenDao(appConfig.mongoRefreshToken))
 
     // configure

--- a/src/main/kotlin/Application.kt
+++ b/src/main/kotlin/Application.kt
@@ -40,9 +40,15 @@ internal fun Application.module() {
                 ),
             mongoUser =
                 MongoConfig(
-                    uri = secretConfig.tryGetString("mongodb-user.uri")!!,
-                    database = secretConfig.tryGetString("mongodb-user.database")!!,
-                    collection = secretConfig.tryGetString("mongodb-user.collection")!!,
+                    uri = secretConfig.tryGetString("mongodb-users.uri")!!,
+                    database = secretConfig.tryGetString("mongodb-users.database")!!,
+                    collection = secretConfig.tryGetString("mongodb-users.collection")!!,
+                ),
+            mongoRefreshTokens =
+                MongoConfig(
+                    uri = secretConfig.tryGetString("mongodb-refresh-tokens.uri")!!,
+                    database = secretConfig.tryGetString("mongodb-refresh-tokens.database")!!,
+                    collection = secretConfig.tryGetString("mongodb-refresh-tokens.collection")!!,
                 ),
             oAuthGoogle =
                 OAuthConfig(

--- a/src/main/kotlin/Application.kt
+++ b/src/main/kotlin/Application.kt
@@ -33,7 +33,6 @@ internal fun Application.module() {
         AppConfig(
             jwt =
                 JwtConfig(
-                    audience = config.tryGetString("jwt.audience")!!,
                     issuer = config.tryGetString("jwt.issuer")!!,
                     secret = secretConfig.tryGetString("jwt.secret")!!,
                 ),

--- a/src/main/kotlin/adapter/MongoRefreshTokenRepository.kt
+++ b/src/main/kotlin/adapter/MongoRefreshTokenRepository.kt
@@ -20,7 +20,7 @@ class MongoRefreshTokenRepository(
             .updateOne(
                 Filters.and(
                     Filters.eq(RefreshTokenDocument.FIELD_VALUE, token.value),
-                    Filters.ne(RefreshTokenDocument.FIELD_STATUS, null),
+                    Filters.eq(RefreshTokenDocument.FIELD_STATUS, null),
                 ),
                 Updates.set(RefreshTokenDocument.FIELD_STATUS, "INVALIDATED"),
             ).modifiedCount != 0L

--- a/src/main/kotlin/adapter/MongoRefreshTokenRepository.kt
+++ b/src/main/kotlin/adapter/MongoRefreshTokenRepository.kt
@@ -1,0 +1,69 @@
+package com.example.adapter
+
+import com.example.domain.token.RefreshToken
+import com.example.domain.token.RefreshTokenRepository
+import com.example.domain.token.TokenId
+import com.example.domain.user.UserId
+import com.mongodb.client.MongoCollection
+import com.mongodb.client.model.Filters
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.time.Clock
+import java.time.Instant
+
+class MongoRefreshTokenRepository(
+    private val dao: MongoCollection<RefreshTokenDocument>,
+    private val clock: Clock,
+) : RefreshTokenRepository {
+    override suspend fun findActiveByTokenId(tokenId: TokenId): Flow<RefreshToken> =
+        dao
+            .find(
+                Filters.and(
+                    Filters.eq(RefreshTokenDocument.FIELD_USER_ID, tokenId.userId.value),
+                    Filters.eq(RefreshTokenDocument.FIELD_PAIRING_KEY, tokenId.pairingKey),
+                    Filters.gt(RefreshTokenDocument.FIELD_EXPIRES_IN, clock.millis()),
+                ),
+            ).asFlow()
+            .map { it.toDomain() }
+
+    override suspend fun save(token: RefreshToken) {
+        dao.insertOne(token.toDocument())
+    }
+
+    private fun RefreshToken.toDocument() =
+        RefreshTokenDocument(
+            userId = tokenId.userId.value,
+            pairingKey = tokenId.pairingKey,
+            expiresIn = expiresIn.toEpochMilli(),
+            value = value,
+        )
+
+    private fun RefreshTokenDocument.toDomain() =
+        RefreshToken(
+            value = value,
+            tokenId = TokenId(UserId(userId), pairingKey),
+            expiresIn = Instant.ofEpochMilli(expiresIn),
+        )
+}
+
+@Serializable
+data class RefreshTokenDocument(
+    @SerialName(FIELD_USER_ID)
+    val userId: String,
+    @SerialName(FIELD_PAIRING_KEY)
+    val pairingKey: String,
+    @SerialName(FIELD_EXPIRES_IN)
+    val expiresIn: Long,
+    @SerialName(FIELD_VALUE)
+    val value: String,
+) {
+    companion object {
+        const val FIELD_USER_ID = "user_id"
+        const val FIELD_PAIRING_KEY = "pairing_key"
+        const val FIELD_EXPIRES_IN = "expires_in"
+        const val FIELD_VALUE = "value"
+    }
+}

--- a/src/main/kotlin/adapter/MongoRefreshTokenRepository.kt
+++ b/src/main/kotlin/adapter/MongoRefreshTokenRepository.kt
@@ -2,36 +2,28 @@ package com.example.adapter
 
 import com.example.domain.token.RefreshToken
 import com.example.domain.token.RefreshTokenRepository
-import com.example.domain.token.TokenId
-import com.example.domain.user.UserId
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.model.Filters
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.map
+import com.mongodb.client.model.Updates
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.time.Clock
-import java.time.Instant
 
 class MongoRefreshTokenRepository(
     private val dao: MongoCollection<RefreshTokenDocument>,
-    private val clock: Clock,
 ) : RefreshTokenRepository {
-    override suspend fun findActiveByTokenId(tokenId: TokenId): Flow<RefreshToken> =
-        dao
-            .find(
-                Filters.and(
-                    Filters.eq(RefreshTokenDocument.FIELD_USER_ID, tokenId.userId.value),
-                    Filters.eq(RefreshTokenDocument.FIELD_PAIRING_KEY, tokenId.pairingKey),
-                    Filters.gt(RefreshTokenDocument.FIELD_EXPIRES_IN, clock.millis()),
-                ),
-            ).asFlow()
-            .map { it.toDomain() }
-
     override suspend fun save(token: RefreshToken) {
         dao.insertOne(token.toDocument())
     }
+
+    override suspend fun invalidateOnce(token: RefreshToken): Boolean =
+        dao
+            .updateOne(
+                Filters.and(
+                    Filters.eq(RefreshTokenDocument.FIELD_VALUE, token.value),
+                    Filters.ne(RefreshTokenDocument.FIELD_STATUS, null),
+                ),
+                Updates.set(RefreshTokenDocument.FIELD_STATUS, "INVALIDATED"),
+            ).modifiedCount != 0L
 
     private fun RefreshToken.toDocument() =
         RefreshTokenDocument(
@@ -39,13 +31,6 @@ class MongoRefreshTokenRepository(
             pairingKey = tokenId.pairingKey,
             expiresIn = expiresIn.toEpochMilli(),
             value = value,
-        )
-
-    private fun RefreshTokenDocument.toDomain() =
-        RefreshToken(
-            value = value,
-            tokenId = TokenId(UserId(userId), pairingKey),
-            expiresIn = Instant.ofEpochMilli(expiresIn),
         )
 }
 
@@ -59,11 +44,14 @@ data class RefreshTokenDocument(
     val expiresIn: Long,
     @SerialName(FIELD_VALUE)
     val value: String,
+    @SerialName(FIELD_STATUS)
+    val status: String? = null,
 ) {
     companion object {
         const val FIELD_USER_ID = "user_id"
         const val FIELD_PAIRING_KEY = "pairing_key"
         const val FIELD_EXPIRES_IN = "expires_in"
         const val FIELD_VALUE = "value"
+        const val FIELD_STATUS = "status"
     }
 }

--- a/src/main/kotlin/adapter/MongoUserRepository.kt
+++ b/src/main/kotlin/adapter/MongoUserRepository.kt
@@ -4,10 +4,10 @@ import com.example.domain.user.User
 import com.example.domain.user.UserId
 import com.example.domain.user.UserRepository
 import com.mongodb.client.MongoCollection
+import com.mongodb.client.model.Filters
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import org.bson.Document
 import org.bson.codecs.kotlinx.ObjectIdSerializer
 import org.bson.types.ObjectId
 import java.time.Instant
@@ -17,8 +17,9 @@ class MongoUserRepository(
 ) : UserRepository {
     override suspend fun findByEmail(email: String): User? =
         dao
-            .find(EMAIL(email))
-            .firstOrNull()
+            .find(
+                Filters.eq(UserDocument.FIELD_EMAIL, email),
+            ).firstOrNull()
             ?.toDomain()
 
     override suspend fun save(user: User) {
@@ -38,10 +39,6 @@ class MongoUserRepository(
             email = email,
             signedUpAt = Instant.ofEpochMilli(signedUpAt),
         )
-
-    private companion object {
-        val EMAIL: (String) -> Document = { Document(UserDocument.FIELD_EMAIL, it) }
-    }
 }
 
 @Serializable

--- a/src/main/kotlin/config/AppConfig.kt
+++ b/src/main/kotlin/config/AppConfig.kt
@@ -3,6 +3,7 @@ package com.example.config
 data class AppConfig(
     val jwt: JwtConfig,
     val mongoUser: MongoConfig,
+    val mongoRefreshToken: MongoConfig,
     val oAuthGoogle: OAuthConfig,
     val googleUrl: UrlConfig,
 )

--- a/src/main/kotlin/config/JwtConfig.kt
+++ b/src/main/kotlin/config/JwtConfig.kt
@@ -1,7 +1,6 @@
 package com.example.config
 
 data class JwtConfig(
-    val audience: String,
     val issuer: String,
     val secret: String,
 )

--- a/src/main/kotlin/domain/token/RefreshTokenRepository.kt
+++ b/src/main/kotlin/domain/token/RefreshTokenRepository.kt
@@ -1,9 +1,7 @@
 package com.example.domain.token
 
-import kotlinx.coroutines.flow.Flow
-
 interface RefreshTokenRepository {
-    suspend fun findActiveByTokenId(tokenId: TokenId): Flow<RefreshToken>
-
     suspend fun save(token: RefreshToken)
+
+    suspend fun invalidateOnce(token: RefreshToken): Boolean
 }

--- a/src/main/kotlin/domain/token/RefreshTokenRepository.kt
+++ b/src/main/kotlin/domain/token/RefreshTokenRepository.kt
@@ -1,0 +1,9 @@
+package com.example.domain.token
+
+import kotlinx.coroutines.flow.Flow
+
+interface RefreshTokenRepository {
+    suspend fun findActiveByTokenId(tokenId: TokenId): Flow<RefreshToken>
+
+    suspend fun save(token: RefreshToken)
+}

--- a/src/main/kotlin/domain/token/TokenId.kt
+++ b/src/main/kotlin/domain/token/TokenId.kt
@@ -1,6 +1,7 @@
 package com.example.domain.token
 
 import com.example.domain.user.UserId
+import java.time.Duration
 import java.time.Instant
 import java.util.UUID
 
@@ -13,9 +14,17 @@ data class RefreshToken(
     val value: String,
     val tokenId: TokenId,
     val expiresIn: Instant,
-)
+) {
+    companion object {
+        internal val EXPIRES_IN = Duration.ofHours(6)
+    }
+}
 
 @JvmInline
 value class AccessToken(
     val value: String,
-)
+) {
+    companion object {
+        internal val EXPIRES_IN = Duration.ofMinutes(15)
+    }
+}

--- a/src/main/kotlin/domain/token/TokenId.kt
+++ b/src/main/kotlin/domain/token/TokenId.kt
@@ -1,9 +1,21 @@
 package com.example.domain.token
 
 import com.example.domain.user.UserId
+import java.time.Instant
 import java.util.UUID
 
 data class TokenId(
     val userId: UserId,
     val pairingKey: String = UUID.randomUUID().toString().replace("-", ""),
+)
+
+data class RefreshToken(
+    val value: String,
+    val tokenId: TokenId,
+    val expiresIn: Instant,
+)
+
+@JvmInline
+value class AccessToken(
+    val value: String,
 )

--- a/src/main/kotlin/domain/token/TokenProvider.kt
+++ b/src/main/kotlin/domain/token/TokenProvider.kt
@@ -26,7 +26,6 @@ class TokenProvider(
             .create()
             .withAudience(jwtConfig.audience)
             .withIssuer(jwtConfig.issuer)
-            .withIssuedAt(issuedAt)
             .withExpiresAt(expiresIn)
             .withJWTId(tokenId.pairingKey)
             .withSubject(tokenId.userId.value)

--- a/src/main/kotlin/domain/token/TokenProvider.kt
+++ b/src/main/kotlin/domain/token/TokenProvider.kt
@@ -20,21 +20,21 @@ class TokenProvider(
 
     private fun issueRefreshToken(tokenId: TokenId): RefreshToken {
         val issuedAt = clock.instant()
-        val expiresIn = issuedAt.plus(REFRESH_TOKEN_EXPIRES_IN)
+        val expiresIn = issuedAt.plus(RefreshToken.EXPIRES_IN)
 
         return JWT
             .create()
             .withAudience(jwtConfig.audience)
             .withIssuer(jwtConfig.issuer)
-            .withExpiresAt(expiresIn)
             .withJWTId(tokenId.pairingKey)
             .withSubject(tokenId.userId.value)
+            .withIssuedAt(issuedAt)
             .sign(Algorithm.HMAC256(jwtConfig.secret))
             .let { RefreshToken(it, tokenId, expiresIn) }
     }
 
     private fun issueAccessToken(tokenId: TokenId): AccessToken {
-        val expiresIn = clock.instant().plus(ACCESS_TOKEN_EXPIRES_IN)
+        val expiresIn = clock.instant().plus(AccessToken.EXPIRES_IN)
         val jitter = Random.nextLong(1, 60).let { Duration.ofSeconds(it) }
 
         return JWT
@@ -46,10 +46,5 @@ class TokenProvider(
             .withSubject(tokenId.userId.value)
             .sign(Algorithm.HMAC256(jwtConfig.secret))
             .let { AccessToken(it) }
-    }
-
-    companion object {
-        private val ACCESS_TOKEN_EXPIRES_IN = Duration.ofMinutes(15)
-        private val REFRESH_TOKEN_EXPIRES_IN = Duration.ofHours(6)
     }
 }

--- a/src/main/kotlin/domain/token/TokenProvider.kt
+++ b/src/main/kotlin/domain/token/TokenProvider.kt
@@ -3,7 +3,6 @@ package com.example.domain.token
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.example.config.JwtConfig
-import com.example.domain.user.UserId
 import java.time.Clock
 import java.time.Duration
 import kotlin.random.Random
@@ -13,16 +12,13 @@ class TokenProvider(
     private val clock: Clock,
 ) {
     fun issueAll(tokenId: TokenId): Pair<AccessToken, RefreshToken> {
-        val refreshToken = issueRefreshToken(tokenId.userId, tokenId.pairingKey)
-        val accessToken = issueAccessToken(tokenId.userId, tokenId.pairingKey)
+        val refreshToken = issueRefreshToken(tokenId)
+        val accessToken = issueAccessToken(tokenId)
 
         return accessToken to refreshToken
     }
 
-    private fun issueRefreshToken(
-        userId: UserId,
-        pairingKey: String,
-    ): RefreshToken {
+    private fun issueRefreshToken(tokenId: TokenId): RefreshToken {
         val issuedAt = clock.instant()
         val expiresIn = issuedAt.plus(REFRESH_TOKEN_EXPIRES_IN)
 
@@ -32,16 +28,13 @@ class TokenProvider(
             .withIssuer(jwtConfig.issuer)
             .withIssuedAt(issuedAt)
             .withExpiresAt(expiresIn)
-            .withJWTId(pairingKey)
-            .withSubject(userId.value)
+            .withJWTId(tokenId.pairingKey)
+            .withSubject(tokenId.userId.value)
             .sign(Algorithm.HMAC256(jwtConfig.secret))
-            .let { RefreshToken(it) }
+            .let { RefreshToken(it, tokenId, expiresIn) }
     }
 
-    private fun issueAccessToken(
-        userId: UserId,
-        pairingKey: String,
-    ): AccessToken {
+    private fun issueAccessToken(tokenId: TokenId): AccessToken {
         val expiresIn = clock.instant().plus(ACCESS_TOKEN_EXPIRES_IN)
         val jitter = Random.nextLong(1, 60).let { Duration.ofSeconds(it) }
 
@@ -50,8 +43,8 @@ class TokenProvider(
             .withAudience(jwtConfig.audience)
             .withIssuer(jwtConfig.issuer)
             .withExpiresAt(expiresIn.plus(jitter))
-            .withJWTId(pairingKey)
-            .withSubject(userId.value)
+            .withJWTId(tokenId.pairingKey)
+            .withSubject(tokenId.userId.value)
             .sign(Algorithm.HMAC256(jwtConfig.secret))
             .let { AccessToken(it) }
     }
@@ -61,13 +54,3 @@ class TokenProvider(
         private val REFRESH_TOKEN_EXPIRES_IN = Duration.ofHours(6)
     }
 }
-
-@JvmInline
-value class AccessToken internal constructor(
-    val value: String,
-)
-
-@JvmInline
-value class RefreshToken internal constructor(
-    val value: String,
-)

--- a/src/main/kotlin/domain/token/TokenProvider.kt
+++ b/src/main/kotlin/domain/token/TokenProvider.kt
@@ -24,7 +24,6 @@ class TokenProvider(
 
         return JWT
             .create()
-            .withAudience(jwtConfig.audience)
             .withIssuer(jwtConfig.issuer)
             .withJWTId(tokenId.pairingKey)
             .withSubject(tokenId.userId.value)
@@ -39,7 +38,6 @@ class TokenProvider(
 
         return JWT
             .create()
-            .withAudience(jwtConfig.audience)
             .withIssuer(jwtConfig.issuer)
             .withExpiresAt(expiresIn.plus(jitter))
             .withJWTId(tokenId.pairingKey)

--- a/src/main/kotlin/domain/token/TokenValidator.kt
+++ b/src/main/kotlin/domain/token/TokenValidator.kt
@@ -13,11 +13,11 @@ class TokenValidator(
     private val jwtConfig: JwtConfig,
 ) {
     fun validate(
-        accessToken: AccessToken,
-        refreshToken: RefreshToken,
+        accessToken: String,
+        refreshToken: String,
     ): Either<Error, TokenId> {
-        val decodedAccessToken = JWT.decode(accessToken.value)
-        val decodedRefreshToken = JWT.decode(refreshToken.value)
+        val decodedAccessToken = JWT.decode(accessToken)
+        val decodedRefreshToken = JWT.decode(refreshToken)
         if (
             decodedAccessToken.id != decodedRefreshToken.id ||
             decodedAccessToken.subject != decodedRefreshToken.subject

--- a/src/main/kotlin/domain/token/TokenValidator.kt
+++ b/src/main/kotlin/domain/token/TokenValidator.kt
@@ -36,7 +36,6 @@ class TokenValidator(
             val jwtVerifier =
                 JWT
                     .require(Algorithm.HMAC256(jwtConfig.secret))
-                    .withAudience(jwtConfig.audience)
                     .withIssuer(jwtConfig.issuer)
                     .withJWTId(tokenId.pairingKey)
                     .withSubject(tokenId.userId.value)

--- a/src/main/kotlin/domain/token/TokenValidator.kt
+++ b/src/main/kotlin/domain/token/TokenValidator.kt
@@ -1,8 +1,8 @@
 package com.example.domain.token
 
 import arrow.core.Either
+import arrow.core.Either.Companion.catch
 import arrow.core.left
-import arrow.core.right
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.exceptions.TokenExpiredException
@@ -15,7 +15,7 @@ class TokenValidator(
     fun validate(
         accessToken: String,
         refreshToken: String,
-    ): Either<Error, TokenId> {
+    ): Either<Error, Pair<AccessToken, RefreshToken>> {
         val decodedAccessToken = JWT.decode(accessToken)
         val decodedRefreshToken = JWT.decode(refreshToken)
         if (
@@ -25,13 +25,18 @@ class TokenValidator(
             return Error.Unpaired.left()
         }
 
+        val tokenId =
+            TokenId(
+                userId = UserId(decodedRefreshToken.subject),
+                pairingKey = decodedRefreshToken.id,
+            )
         val jwtVerifier =
             JWT
                 .require(Algorithm.HMAC256(jwtConfig.secret))
                 .withAudience(jwtConfig.audience)
                 .withIssuer(jwtConfig.issuer)
-                .withJWTId(decodedRefreshToken.id)
-                .withSubject(decodedRefreshToken.subject)
+                .withJWTId(tokenId.pairingKey)
+                .withSubject(tokenId.userId.value)
                 .build()
 
         runCatching {
@@ -40,39 +45,34 @@ class TokenValidator(
             return Error.Invalid.left()
         }
 
-        return runCatching {
-            jwtVerifier
-                .verify(decodedAccessToken)
-                .let {
-                    TokenId(
-                        userId = UserId(it.subject),
-                        pairingKey = it.id,
-                    )
-                }.right()
-        }.getOrElse {
+        return catch {
+            jwtVerifier.verify(decodedAccessToken)
+        }.mapLeft {
             when (it) {
                 is TokenExpiredException -> {
-                    Error
-                        .Expired(
-                            TokenId(
-                                userId = UserId(decodedRefreshToken.subject),
-                                pairingKey = decodedRefreshToken.id,
-                            ),
-                        ).left()
+                    Error.AccessTokenExpired(
+                        RefreshToken(
+                            refreshToken,
+                            tokenId,
+                            decodedRefreshToken.expiresAtAsInstant,
+                        ),
+                    )
                 }
 
                 else -> {
-                    Error.Invalid.left()
+                    Error.Invalid
                 }
             }
+        }.map {
+            AccessToken(accessToken) to RefreshToken(refreshToken, tokenId, decodedRefreshToken.expiresAtAsInstant)
         }
     }
 
     sealed interface Error {
         data object Unpaired : Error
 
-        data class Expired(
-            val tokenId: TokenId,
+        data class AccessTokenExpired(
+            val refreshToken: RefreshToken,
         ) : Error
 
         data object Invalid : Error

--- a/src/main/kotlin/module/Databases.kt
+++ b/src/main/kotlin/module/Databases.kt
@@ -1,5 +1,6 @@
 package com.example.module
 
+import com.example.adapter.RefreshTokenDocument
 import com.example.adapter.UserDocument
 import com.example.config.MongoConfig
 import com.mongodb.ConnectionString
@@ -24,4 +25,21 @@ internal fun Application.userDao(mongoConfig: MongoConfig): MongoCollection<User
     return mongoClient
         .getDatabase(mongoConfig.database)
         .getCollection(mongoConfig.collection, UserDocument::class.java)
+}
+
+internal fun Application.refreshTokenDao(mongoConfig: MongoConfig): MongoCollection<RefreshTokenDocument> {
+    val mongoClient =
+        MongoClientSettings
+            .builder()
+            .applyConnectionString(ConnectionString(mongoConfig.uri))
+            .build()
+            .let { MongoClients.create(it) }
+
+    monitor.subscribe(ApplicationStopped) {
+        mongoClient.close()
+    }
+
+    return mongoClient
+        .getDatabase(mongoConfig.database)
+        .getCollection(mongoConfig.collection, RefreshTokenDocument::class.java)
 }

--- a/src/main/kotlin/module/Routing.kt
+++ b/src/main/kotlin/module/Routing.kt
@@ -1,5 +1,6 @@
 package com.example.module
 
+import com.example.domain.token.RefreshTokenRepository
 import com.example.domain.token.TokenProvider
 import com.example.domain.token.TokenValidator
 import com.example.domain.user.UserAuthorizationService
@@ -13,6 +14,7 @@ internal fun Application.configureRouting(
     userAuthorizationService: UserAuthorizationService,
     tokenProvider: TokenProvider,
     tokenValidator: TokenValidator,
+    refreshTokenRepository: RefreshTokenRepository,
 ) {
     routing {
         get("/") {
@@ -23,6 +25,7 @@ internal fun Application.configureRouting(
             userAuthorizationService = userAuthorizationService,
             tokenProvider = tokenProvider,
             tokenValidator = tokenValidator,
+            refreshTokenRepository = refreshTokenRepository,
         )
     }
 }

--- a/src/main/kotlin/module/Security.kt
+++ b/src/main/kotlin/module/Security.kt
@@ -27,16 +27,11 @@ internal fun Application.configureSecurity(
             verifier(
                 JWT
                     .require(Algorithm.HMAC256(jwtConfig.secret))
-                    .withAudience(jwtConfig.audience)
                     .withIssuer(jwtConfig.issuer)
                     .build(),
             )
             validate { credential ->
-                if (credential.payload.audience.contains(jwtConfig.audience)) {
-                    JWTPrincipal(credential.payload)
-                } else {
-                    null
-                }
+                JWTPrincipal(credential.payload)
             }
         }
     }

--- a/src/main/kotlin/module/Security.kt
+++ b/src/main/kotlin/module/Security.kt
@@ -15,7 +15,8 @@ import io.ktor.server.auth.jwt.jwt
 import io.ktor.server.auth.oauth
 
 /**
- * @see com.example.domain.TokenProvider
+ * @see com.example.domain.token.TokenProvider
+ * @see com.example.domain.token.TokenValidator
  */
 internal fun Application.configureSecurity(
     jwtConfig: JwtConfig,

--- a/src/main/kotlin/route/auth/AuthRoute.kt
+++ b/src/main/kotlin/route/auth/AuthRoute.kt
@@ -34,7 +34,7 @@ fun Routing.authorization(
                         .issueAll(TokenId(user.id))
                         .also { refreshTokenRepository.save(it.second) }
 
-                call.respond(TokenDto(accessToken.value, refreshToken.value))
+                return@get call.respond(TokenDto(accessToken.value, refreshToken.value))
             }
         }
     }
@@ -51,7 +51,7 @@ fun Routing.authorization(
                         runCatching {
                             val stolen = !refreshTokenRepository.invalidateOnce(it.refreshToken)
                             if (stolen) {
-                                call.respond(HttpStatusCode.Unauthorized)
+                                return@post call.respond(HttpStatusCode.Unauthorized)
                             }
                         }
 
@@ -60,15 +60,15 @@ fun Routing.authorization(
                                 .issueAll(it.refreshToken.tokenId)
                                 .also { refreshTokenRepository.save(it.second) }
 
-                        call.respond(TokenDto(accessToken.value, refreshToken.value))
+                        return@post call.respond(TokenDto(accessToken.value, refreshToken.value))
                     }
 
                     else -> {
-                        call.respond(HttpStatusCode.Unauthorized)
+                        return@post call.respond(HttpStatusCode.Unauthorized)
                     }
                 }
             }.onRight { (accessToken, refreshToken) ->
-                call.respond(TokenDto(accessToken.value, refreshToken.value))
+                return@post call.respond(TokenDto(accessToken.value, refreshToken.value))
             }
     }
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -10,7 +10,6 @@ ktor {
 
 jwt {
   issuer = "alt-tab"
-  audience = "jwt-audience"
 }
 
 google {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,18 +1,18 @@
 ktor {
-    deployment {
-        port = 8080
-        port = ${?PORT}
-    }
-    application {
-        modules = [ com.example.ApplicationKt.module ]
-    }
+  deployment {
+    port = 8080
+    port = ${?PORT}
+  }
+  application {
+    modules = [com.example.ApplicationKt.module]
+  }
 }
 
 jwt {
-    issuer = "alt-tab"
-    audience = "jwt-audience"
+  issuer = "alt-tab"
+  audience = "jwt-audience"
 }
 
 google {
-    baseUrl = "https://www.googleapis.com/oauth2/"
+  baseUrl = "https://www.googleapis.com/oauth2/"
 }


### PR DESCRIPTION
## 🔥 AS-IS

- AccessToken이 만료, RefreshToken이 유효한 경우 무한정 토큰 발급

## 🚀 TO-BE

- RefreshToken이 유효해도 1회만 한해 새로운 토큰을 발급할 수 있도록 한다.
- 이를 위해 RefeshToken을 DB에 저장합니다.
- 토큰 클레임으로 들어가는 aud 제거합니다.

## 📝 리뷰시 중점 사항

- 

## ✅ 체크 리스트 

- [x] 코드가 의도한 대로 동작하는가?

## 🔗 관련 이슈
#### (이슈 넘버가 있다면 적어주세요.)

-  
