### PR TITLE
feat: 유저의 id를 생성하기 위해 도메인에서 db에 의존하던 문제 수정

### DIFF
--- a/src/main/kotlin/Application.kt
+++ b/src/main/kotlin/Application.kt
@@ -61,11 +61,11 @@ internal fun Application.module() {
         )
 
     // dependency
-    val userEmailRepository = GoogleClient(appConfig.googleUrl.baseUrl)
-    val userRepository = MongoUserRepository(userDao(appConfig.mongoUser))
     val clock = Clock.systemDefaultZone()
+    val userEmailRepository = GoogleClient(appConfig.googleUrl.baseUrl)
+    val userRepository = MongoUserRepository(userDao(appConfig.mongoUser), clock)
 
-    val userAuthorizationService = UserAuthorizationService(userEmailRepository, userRepository, clock)
+    val userAuthorizationService = UserAuthorizationService(userEmailRepository, userRepository)
 
     val tokenProvider = TokenProvider(appConfig.jwt, clock)
     val tokenValidator = TokenValidator(appConfig.jwt, clock)

--- a/src/main/kotlin/adapter/MongoUserRepository.kt
+++ b/src/main/kotlin/adapter/MongoUserRepository.kt
@@ -10,10 +10,12 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.bson.codecs.kotlinx.ObjectIdSerializer
 import org.bson.types.ObjectId
+import java.time.Clock
 import java.time.Instant
 
 class MongoUserRepository(
     private val dao: MongoCollection<UserDocument>,
+    private val clock: Clock,
 ) : UserRepository {
     override suspend fun find(userId: UserId): User? =
         dao
@@ -29,16 +31,17 @@ class MongoUserRepository(
             ).firstOrNull()
             ?.toDomain()
 
-    override suspend fun save(user: User) {
-        dao.insertOne(user.toDocument())
-    }
+    override suspend fun signUp(email: String): User {
+        val user =
+            UserDocument(
+                id = ObjectId(),
+                email = email,
+                signedUpAt = clock.millis(),
+            )
+        dao.insertOne(user)
 
-    private fun User.toDocument() =
-        UserDocument(
-            id = ObjectId(id.value),
-            email = email,
-            signedUpAt = signedUpAt.toEpochMilli(),
-        )
+        return user.toDomain()
+    }
 
     private fun UserDocument.toDomain() =
         User(

--- a/src/main/kotlin/domain/token/TokenId.kt
+++ b/src/main/kotlin/domain/token/TokenId.kt
@@ -10,6 +10,7 @@ data class TokenId(
     val pairingKey: String = UUID.randomUUID().toString().replace("-", ""),
 )
 
+@ConsistentCopyVisibility
 data class RefreshToken internal constructor(
     val value: String,
     val tokenId: TokenId,
@@ -20,6 +21,7 @@ data class RefreshToken internal constructor(
     }
 }
 
+@ConsistentCopyVisibility
 data class AccessToken internal constructor(
     val value: String,
     val tokenId: TokenId,

--- a/src/main/kotlin/domain/user/UserAuthorizationService.kt
+++ b/src/main/kotlin/domain/user/UserAuthorizationService.kt
@@ -1,12 +1,8 @@
 package com.example.domain.user
 
-import org.bson.types.ObjectId
-import java.time.Clock
-
 class UserAuthorizationService(
     private val googleEmailRepository: UserEmailRepository,
     private val userRepository: UserRepository,
-    private val clock: Clock,
 ) {
     suspend fun byGoogleOAuth(accessToken: String): User {
         val user =
@@ -14,16 +10,9 @@ class UserAuthorizationService(
                 .findByAccessToken(accessToken)
                 .let {
                     userRepository.findByEmail(it)
-                        ?: signUp(it)
+                        ?: userRepository.signUp(it)
                 }
 
         return user
     }
-
-    private suspend fun signUp(email: String): User =
-        User(
-            id = UserId(ObjectId().toHexString()),
-            email = email,
-            signedUpAt = clock.instant(),
-        ).also { userRepository.save(it) }
 }

--- a/src/main/kotlin/domain/user/UserRepository.kt
+++ b/src/main/kotlin/domain/user/UserRepository.kt
@@ -5,5 +5,5 @@ interface UserRepository {
 
     suspend fun findByEmail(email: String): User?
 
-    suspend fun save(user: User)
+    suspend fun signUp(email: String): User
 }

--- a/src/test/kotlin/Application.kt
+++ b/src/test/kotlin/Application.kt
@@ -29,8 +29,9 @@ import io.ktor.server.testing.testApplication
 
 private fun Application.testModule() {
     configureSecurity(
-        jwtConfig = appConfig.jwt,
         oAuthGoogleConfig = appConfig.oAuthGoogle,
+        tokenValidator = tokenValidator,
+        userRepository = userRepository,
     )
     configureHTTP()
     configureSerialization()
@@ -78,11 +79,11 @@ private val appConfig =
     )
 
 // dependency
-internal val userEmailRepository = FakeUserEmailRepository()
-internal val userRepository = FakeUserRepository()
 internal val clock = FakeClock()
+internal val userEmailRepository = FakeUserEmailRepository()
+internal val userRepository = FakeUserRepository(clock)
 
-internal val userAuthorizationService = UserAuthorizationService(userEmailRepository, userRepository, clock)
+internal val userAuthorizationService = UserAuthorizationService(userEmailRepository, userRepository)
 
 internal val tokenProvider = TokenProvider(appConfig.jwt, clock)
 internal val tokenValidator = TokenValidator(appConfig.jwt, clock)

--- a/src/test/kotlin/domain/user/FakeUserRepository.kt
+++ b/src/test/kotlin/domain/user/FakeUserRepository.kt
@@ -2,23 +2,29 @@ package com.example.domain.user
 
 import com.example.adapter.UserDocument
 import org.bson.types.ObjectId
+import java.time.Clock
 import java.time.Instant
 
-class FakeUserRepository : UserRepository {
+class FakeUserRepository(
+    private val clock: Clock,
+) : UserRepository {
     private val users = mutableListOf<UserDocument>()
+
+    override suspend fun find(userId: UserId): User? = users.find { it.id.toHexString() == userId.value }?.toDomain()
 
     override suspend fun findByEmail(email: String): User? = users.find { it.email == email }?.toDomain()
 
-    override suspend fun save(user: User) {
-        users.add(user.toDocument())
-    }
+    override suspend fun signUp(email: String): User {
+        val user =
+            UserDocument(
+                id = ObjectId(),
+                email = email,
+                signedUpAt = clock.millis(),
+            )
+        users.add(user)
 
-    private fun User.toDocument() =
-        UserDocument(
-            id = ObjectId(id.value),
-            email = email,
-            signedUpAt = signedUpAt.toEpochMilli(),
-        )
+        return user.toDomain()
+    }
 
     private fun UserDocument.toDomain() =
         User(


### PR DESCRIPTION
## 🔥 AS-IS

- 회원가입 서비스에서 mongodb의 ObjectId에 의존

## 🚀 TO-BE

- UserRepository에서 회원가입의 책임을 담당한다.
- 회원가입 서비스에서는 레포지토리로 필요한 정보들만 넘겨준다.

## 📝 리뷰시 중점 사항

- 

## ✅ 체크 리스트 

- [x] 코드가 의도한 대로 동작하는가?

## 🔗 관련 이슈
#### (이슈 넘버가 있다면 적어주세요.)

-  
