### PR TITLE
feat: oauth 인증이 완료됨을 알리는 /oauth/complete 추가

### DIFF
--- a/src/main/kotlin/route/auth/AuthRoute.kt
+++ b/src/main/kotlin/route/auth/AuthRoute.kt
@@ -12,6 +12,7 @@ import io.ktor.server.auth.authenticate
 import io.ktor.server.auth.principal
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
+import io.ktor.server.response.respondRedirect
 import io.ktor.server.routing.Routing
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
@@ -40,8 +41,13 @@ fun Routing.authorization(
                             stashSettingRepository.init(user.id)
                         }
 
-                return@get call.respond(TokenDto(accessToken.value, refreshToken.value))
+                return@get call.respondRedirect("/oauth/complete#access_token=${accessToken.value}&refresh_token=${refreshToken.value}")
             }
+        }
+
+        // 브라우저 익스텐션에서 팝업으로 띄워진 창의 응답을 확인하기 위해 앵커(#)로 토큰 값을 담아준다.
+        get("/complete") {
+            return@get call.respond(HttpStatusCode.OK)
         }
     }
 


### PR DESCRIPTION
## 🔥 AS-IS

- 서버에서 oauth 인증을 전담하다보니, 서버에서 인증 후 발급해주는 토큰을 익스텐션에서 가져오지 못함.

## 🚀 TO-BE

- /oauth/complete 라는 path로 명시적으로 리다이렉팅 시켜서 인증이 끝났음을 알림.
- 익스텐션에서는 인증 팝업의 url을 감시하고 있다가, 인증이 완료되면 앵커에 담긴 토큰을 저장함.

## 📝 리뷰시 중점 사항

- 

## ✅ 체크 리스트 

- [x] 코드가 의도한 대로 동작하는가?

## 🔗 관련 이슈
#### (이슈 넘버가 있다면 적어주세요.)

-  
