### PR TITLE
feat: 리프레시 토큰 탈취 케이스별 대응을 개선한다.

### DIFF
--- a/src/main/kotlin/adapter/mongodb/MongoRefreshTokenRepository.kt
+++ b/src/main/kotlin/adapter/mongodb/MongoRefreshTokenRepository.kt
@@ -1,7 +1,10 @@
 package com.example.adapter.mongodb
 
+import arrow.core.Either
+import arrow.core.raise.either
 import com.example.domain.token.RefreshToken
 import com.example.domain.token.RefreshTokenRepository
+import com.example.domain.token.RefreshTokenRepository.InvalidateOnceError
 import com.example.domain.token.TokenId
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.model.Filters
@@ -16,25 +19,30 @@ class MongoRefreshTokenRepository(
         dao.insertOne(token.toDocument())
     }
 
-    override suspend fun invalidateOnce(token: RefreshToken): Boolean {
-        val saved =
-            dao
-                .find(
-                    Filters.eq(RefreshTokenDocument.FIELD_VALUE, token.value),
-                ).first()
-        if (saved == null || saved.status != null) {
-            return false
-        }
+    override suspend fun invalidateOnce(token: RefreshToken): Either<InvalidateOnceError, Unit> =
+        either {
+            val saved =
+                dao
+                    .find(
+                        Filters.eq(RefreshTokenDocument.FIELD_VALUE, token.value),
+                    ).first()
+            when {
+                // 탈취된 토큰으로 판단되어 이미 제거된 경우
+                saved == null -> raise(InvalidateOnceError.Purged)
 
-        return dao
-            .updateOne(
-                Filters.and(
-                    Filters.eq(RefreshTokenDocument.FIELD_VALUE, token.value),
-                    Filters.eq(RefreshTokenDocument.FIELD_STATUS, null),
-                ),
-                Updates.set(RefreshTokenDocument.FIELD_STATUS, "INVALIDATED"),
-            ).modifiedCount != 0L
-    }
+                // 재사용할 수 없는 토큰인 경우
+                saved.status != null -> raise(InvalidateOnceError.Invalidated)
+            }
+
+            dao
+                .updateOne(
+                    Filters.and(
+                        Filters.eq(RefreshTokenDocument.FIELD_VALUE, token.value),
+                        Filters.eq(RefreshTokenDocument.FIELD_STATUS, null),
+                    ),
+                    Updates.set(RefreshTokenDocument.FIELD_STATUS, "INVALIDATED"),
+                )
+        }
 
     override suspend fun invalidateAll(tokenId: TokenId) {
         dao.deleteMany(

--- a/src/main/kotlin/domain/token/RefreshTokenRepository.kt
+++ b/src/main/kotlin/domain/token/RefreshTokenRepository.kt
@@ -1,9 +1,17 @@
 package com.example.domain.token
 
+import arrow.core.Either
+
 interface RefreshTokenRepository {
     suspend fun save(token: RefreshToken)
 
-    suspend fun invalidateOnce(token: RefreshToken): Boolean
+    suspend fun invalidateOnce(token: RefreshToken): Either<InvalidateOnceError, Unit>
+
+    sealed interface InvalidateOnceError {
+        data object Purged : InvalidateOnceError
+
+        data object Invalidated : InvalidateOnceError
+    }
 
     suspend fun invalidateAll(tokenId: TokenId)
 }

--- a/src/main/kotlin/route/auth/AuthRoute.kt
+++ b/src/main/kotlin/route/auth/AuthRoute.kt
@@ -4,6 +4,7 @@ import com.example.adapter.rabbitmq.service.InvalidateRefreshTokenMessage
 import com.example.domain.SendAsyncMessage
 import com.example.domain.extension.StashSettingRepository
 import com.example.domain.token.RefreshTokenRepository
+import com.example.domain.token.RefreshTokenRepository.InvalidateOnceError
 import com.example.domain.token.TokenId
 import com.example.domain.token.TokenProvider
 import com.example.domain.token.TokenValidator
@@ -65,17 +66,26 @@ fun Routing.authorization(
                         // 발급보다 먼저 만료시켜야 토큰 탈취에 보다 안전하다.
                         // 에러가 발생해도 사용성에 문제 없는 편이 낫다.
                         runCatching {
-                            val stolen = !refreshTokenRepository.invalidateOnce(error.refreshToken)
-                            if (stolen) {
-                                application.environment.log.warn("refresh token stolen: ${error.refreshToken.value}")
-                                sendAsyncMessage(
-                                    InvalidateRefreshTokenMessage(
-                                        userId = error.refreshToken.tokenId.userId.value,
-                                        pairingKey = error.refreshToken.tokenId.pairingKey,
-                                    ),
-                                )
-                                return@post call.respond(HttpStatusCode.Unauthorized)
-                            }
+                            refreshTokenRepository
+                                .invalidateOnce(error.refreshToken)
+                                .onLeft {
+                                    when (it) {
+                                        InvalidateOnceError.Invalidated -> {
+                                            application.environment.log.warn("refresh token was stolen: ${error.refreshToken.value}")
+                                            sendAsyncMessage(
+                                                InvalidateRefreshTokenMessage(
+                                                    userId = error.refreshToken.tokenId.userId.value,
+                                                    pairingKey = error.refreshToken.tokenId.pairingKey,
+                                                ),
+                                            )
+                                            return@post call.respond(HttpStatusCode.Unauthorized)
+                                        }
+
+                                        InvalidateOnceError.Purged -> {
+                                            return@post call.respond(HttpStatusCode.Unauthorized)
+                                        }
+                                    }
+                                }
                         }.onFailure {
                             application.environment.log.error(
                                 "error occurred while invalidating refresh token",

--- a/src/test/kotlin/Application.kt
+++ b/src/test/kotlin/Application.kt
@@ -49,7 +49,7 @@ private fun Application.testModule() {
         tokenProvider = tokenProvider,
         tokenValidator = tokenValidator,
         refreshTokenRepository = refreshTokenRepository,
-        sendAsyncMessage = invalidateRefreshTokenProducer,
+        sendAsyncMessage = sendAsyncMessage,
         tabGroupRepository = tabGroupRepository,
         clock = clock,
     )
@@ -148,7 +148,7 @@ internal val refreshTokenRepository = FakeRefreshTokenRepository()
 
 internal val tabGroupRepository = FakeTabGroupRepository()
 
-internal val invalidateRefreshTokenProducer = mockk<SendAsyncMessage>(relaxed = true)
+internal val sendAsyncMessage = mockk<SendAsyncMessage>(relaxed = true)
 
 internal val bootstrapService = BootstrapService(tokenProvider, userRepository, refreshTokenRepository, stashSettingRepository)
 

--- a/src/test/kotlin/route/auth/AuthRouteTest.kt
+++ b/src/test/kotlin/route/auth/AuthRouteTest.kt
@@ -6,7 +6,8 @@ import com.example.bootstrapService
 import com.example.clock
 import com.example.domain.token.AccessToken
 import com.example.domain.token.RefreshToken
-import com.example.invalidateRefreshTokenProducer
+import com.example.refreshTokenRepository
+import com.example.sendAsyncMessage
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -89,6 +90,8 @@ class AuthRouteTest :
                         client.post("/refresh-tokens") {
                             setBody(TokenDto(accessToken.value, refreshToken.value))
                         }
+                    // simulating token invalidation
+                    refreshTokenRepository.invalidateAll(accessToken.tokenId)
 
                     normalUserResponse.status shouldBe HttpStatusCode.OK
                     normalUserResponse.body<TokenDto>().apply {
@@ -98,7 +101,49 @@ class AuthRouteTest :
 
                     abuserResponse.status shouldBe HttpStatusCode.Unauthorized
                     coVerify {
-                        invalidateRefreshTokenProducer.invoke(
+                        sendAsyncMessage(
+                            InvalidateRefreshTokenMessage(
+                                accessToken.tokenId.userId.value,
+                                accessToken.tokenId.pairingKey,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            describe("탈취된 토큰으로 판단되어 제거된 토큰으로 재갱신하는 경우") {
+                baseTestApplication { client ->
+                    clock.tick(AccessToken.EXPIRES_IN.plusMinutes(1).negated())
+                    val (_, accessToken, refreshToken) = bootstrapService.signUp()
+                    clock.reset()
+
+                    val normalUserResponse =
+                        client.post("/refresh-tokens") {
+                            setBody(TokenDto(accessToken.value, refreshToken.value))
+                        }
+
+                    val abuserResponseBeforePurged =
+                        client.post("/refresh-tokens") {
+                            setBody(TokenDto(accessToken.value, refreshToken.value))
+                        }
+                    // simulating token invalidation
+                    refreshTokenRepository.invalidateAll(accessToken.tokenId)
+
+                    val abuserResponseAfterPurged =
+                        client.post("/refresh-tokens") {
+                            setBody(TokenDto(accessToken.value, refreshToken.value))
+                        }
+
+                    normalUserResponse.status shouldBe HttpStatusCode.OK
+                    normalUserResponse.body<TokenDto>().apply {
+                        this.accessToken shouldNotBe accessToken.value
+                        this.refreshToken shouldNotBe refreshToken.value
+                    }
+
+                    abuserResponseBeforePurged.status shouldBe HttpStatusCode.Unauthorized
+                    abuserResponseAfterPurged.status shouldBe HttpStatusCode.Unauthorized
+                    coVerify(exactly = 1) {
+                        sendAsyncMessage(
                             InvalidateRefreshTokenMessage(
                                 accessToken.tokenId.userId.value,
                                 accessToken.tokenId.pairingKey,

--- a/src/testFixtures/kotlin/adapter/FakeRefreshTokenRepository.kt
+++ b/src/testFixtures/kotlin/adapter/FakeRefreshTokenRepository.kt
@@ -1,8 +1,12 @@
 package adapter
 
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
 import com.example.adapter.mongodb.RefreshTokenDocument
 import com.example.domain.token.RefreshToken
 import com.example.domain.token.RefreshTokenRepository
+import com.example.domain.token.RefreshTokenRepository.InvalidateOnceError
 import com.example.domain.token.TokenId
 
 class FakeRefreshTokenRepository : RefreshTokenRepository {
@@ -12,15 +16,19 @@ class FakeRefreshTokenRepository : RefreshTokenRepository {
         refreshTokens[token.value] = token.toDocument()
     }
 
-    override suspend fun invalidateOnce(token: RefreshToken): Boolean {
+    override suspend fun invalidateOnce(token: RefreshToken): Either<InvalidateOnceError, Unit> {
         val saved = refreshTokens[token.value]
-        if (saved == null || saved.status != null) {
-            return false
+        when {
+            // 탈취된 토큰으로 판단되어 이미 제거된 경우
+            saved == null -> return InvalidateOnceError.Purged.left()
+
+            // 재사용할 수 없는 토큰인 경우
+            saved.status != null -> return InvalidateOnceError.Invalidated.left()
         }
 
-        refreshTokens[token.value] = saved.copy(status = "INVALIDATED")
+        refreshTokens[token.value] = saved!!.copy(status = "INVALIDATED")
 
-        return true
+        return Unit.right()
     }
 
     override suspend fun invalidateAll(tokenId: TokenId) {

--- a/src/testFixtures/kotlin/adapter/FakeRefreshTokenRepository.kt
+++ b/src/testFixtures/kotlin/adapter/FakeRefreshTokenRepository.kt
@@ -17,16 +17,12 @@ class FakeRefreshTokenRepository : RefreshTokenRepository {
     }
 
     override suspend fun invalidateOnce(token: RefreshToken): Either<InvalidateOnceError, Unit> {
-        val saved = refreshTokens[token.value]
-        when {
-            // 탈취된 토큰으로 판단되어 이미 제거된 경우
-            saved == null -> return InvalidateOnceError.Purged.left()
-
-            // 재사용할 수 없는 토큰인 경우
-            saved.status != null -> return InvalidateOnceError.Invalidated.left()
+        val saved = refreshTokens[token.value] ?: return InvalidateOnceError.Purged.left()
+        if (saved.status != null) {
+            return InvalidateOnceError.Invalidated.left()
         }
 
-        refreshTokens[token.value] = saved!!.copy(status = "INVALIDATED")
+        refreshTokens[token.value] = saved.copy(status = "INVALIDATED")
 
         return Unit.right()
     }


### PR DESCRIPTION
## 🔥 AS-IS

- 이미 제거된 토큰이거나 비활성화된 토큰일 경우 메시지큐로 전송

## 🚀 TO-BE

- 이미 제거된 토큰은 무시하고,
- 비활성화된 토큰일 경우에만 메시지큐로 전송

## 📝 리뷰시 중점 사항

- 

## ✅ 체크 리스트 

- [x] 만료된 토큰에 대해 첫번째 리프레시 요청은 메시지큐로 전송.
- [x] 만료된 토큰에 대해 두번째 리프레시 요청은 메시지큐로 전송하지 않음.

## 🔗 관련 이슈
#### (이슈 넘버가 있다면 적어주세요.)

-  
